### PR TITLE
Fix caption parameter in AI tools list

### DIFF
--- a/content/resources/ai-tools-list/index.md
+++ b/content/resources/ai-tools-list/index.md
@@ -31,7 +31,7 @@ options:
 
 <div class="row">
 <div class="col-10 offset-1">
-{{< csv2table path="tools.csv" caption="tools" outputFormat="html" caption="">}}
+{{< csv2table path="tools.csv" caption="tools" outputFormat="html" >}}
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- fix caption parameter for csv2table shortcode in index page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845895286908324a46c3e73fc07274e