### PR TITLE
Remove preview badge from online course page header

### DIFF
--- a/content/online-course/index.md
+++ b/content/online-course/index.md
@@ -1,15 +1,5 @@
 ---
 title: "Open Access AI Course for Educators"
-subtitle: |
- <span style="display:inline-flex;align-items:center;gap:5px;
- background:#e8f5e2;border:1px solid #5a9e30;border-radius:99px;
- padding:3px 10px 3px 8px;font-size:11px;font-weight:600;
- color:#2d6010;letter-spacing:.04em;text-transform:uppercase;
- white-space:nowrap;">
- <span style="width:6px;height:6px;border-radius:50%;
- background:#4c9020;flex-shrink:0;"></span>
- Preview
- </span>
 date: 2026-03-06T00:00:00Z
 draft: false
 categories:


### PR DESCRIPTION
## Summary

- Removes the "Preview" pill badge that appeared in the subtitle of the online course page header.
- The course is now fully live, so the badge is no longer needed.
- Only the `subtitle` front-matter field in `content/online-course/index.md` was changed.

## Test plan

- [ ] Visit the online course page and confirm the "Preview" badge no longer appears in the header

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8gZFfJZRYFkNZYvxZvaE5)_