### PR TITLE
Remove misleading hover lift from course module cards

### DIFF
--- a/content/online-course/index.md
+++ b/content/online-course/index.md
@@ -290,11 +290,10 @@ options:
   .mooc-module-card {
     border: 1px solid #e0e0e0;
     border-radius: 8px;
-    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    transition: box-shadow 0.2s ease-in-out;
   }
   .mooc-module-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12) !important;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08) !important;
   }
   .mooc-module-number {
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary

- Removes the `translateY(-3px)` lift from `.mooc-module-card:hover` — the lift effect created a false affordance making the cards appear clickable
- Cards are informational only; all module content lives in the single Moodle course
- Retains a subtle box-shadow change on hover so the cards still feel polished without signalling interactivity

## Context

Reported by a colleague who clicked each module card expecting navigation and got no response. The hover lift was the root cause of the confusion.

## Test plan

- [ ] Visit `/ai-course-educators/` and hover over module cards — they should not lift
- [ ] Confirm the "Access the Course" buttons (hero and bottom CTA) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)